### PR TITLE
got GET to work on all MVP pages

### DIFF
--- a/src/app/delete-me/page.js
+++ b/src/app/delete-me/page.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function DeleteMe() {
-  return <div>Delete Meeeeeeeeee</div>;
-}

--- a/src/app/songs/[firebaseKey]/page.js
+++ b/src/app/songs/[firebaseKey]/page.js
@@ -2,16 +2,17 @@
 
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { getSingleSong } from '../../../api/songData';
+import { getSingleSongWithTopic } from '../../../api/songData';
 
 export default function ViewSong({ params }) {
   const [song, setSong] = useState(null);
+  console.log(song);
 
   const { firebaseKey } = params;
 
   useEffect(() => {
     console.log('Firebase Key:', firebaseKey);
-    getSingleSong(firebaseKey).then(setSong);
+    getSingleSongWithTopic(firebaseKey).then(setSong);
   }, [firebaseKey]);
 
   // return (
@@ -33,7 +34,7 @@ export default function ViewSong({ params }) {
           <h2>{song.title}</h2>
           <h2>{song.hymnal}</h2>
           <h2>{song.pageNumber}</h2>
-          <h2>{song.topicId}</h2>
+          <h2>{song.topic.topicName}</h2>
         </div>
       ) : (
         <p>Loading...</p>


### PR DESCRIPTION
**Description
**

I edited GET promises into the following:  getSongsAndTopics and getSingleSongWithTopic.  Both of these promises now grab both the song details from the "songs" and "topics" entities of the Firebase Realtime Database.


**Related Issue
**

#29 


**Motivation and Context
**

Users can now view song cards on both the "Songs" and "Song Details" page.


**How Can This Be Tested?
**

Pull down and manually test


**Screenshots (if appropriate):
**



**Types of changes
**

[ ] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ X] Breaking change (fix or feature that would cause existing functionality to change)
