### PR TITLE
User specific get

### DIFF
--- a/src/api/songData.js
+++ b/src/api/songData.js
@@ -2,6 +2,7 @@ import { clientCredentials } from '../utils/client';
 
 const endpoint = clientCredentials.databaseURL;
 
+// GET SONGS AND TOPICS
 const getSongsAndTopics = async () => {
   try {
     // Fetch songs
@@ -55,6 +56,7 @@ const getSongsAndTopics = async () => {
   }
 };
 
+// GET SINGLE SONG WITH TOPIC
 const getSingleSongWithTopic = (firebaseKey) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/songs/${firebaseKey}.json`, {
@@ -89,6 +91,7 @@ const getSingleSongWithTopic = (firebaseKey) =>
       .catch(reject); // Catch errors in the first fetch
   });
 
+// DELETE SONG
 const deleteSong = (firebaseKey) =>
   new Promise((resolve, reject) => {
     fetch(`${endpoint}/songs/${firebaseKey}.json`, {
@@ -106,4 +109,19 @@ const deleteSong = (firebaseKey) =>
       .catch(reject);
   });
 
-export { getSongsAndTopics, getSingleSongWithTopic, deleteSong };
+// ADD SONG
+const addSong = (payload) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/songs.json`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+export { getSongsAndTopics, getSingleSongWithTopic, deleteSong, addSong };

--- a/src/api/songData.js
+++ b/src/api/songData.js
@@ -3,7 +3,7 @@ import { clientCredentials } from '../utils/client';
 const endpoint = clientCredentials.databaseURL;
 
 // GET SONGS AND TOPICS
-const getSongsAndTopics = async () => {
+const getSongsAndTopics = async (uid) => {
   try {
     // Fetch songs
     const songsResponse = await fetch(`${endpoint}/songs.json`, {
@@ -13,10 +13,12 @@ const getSongsAndTopics = async () => {
     const songsData = await songsResponse.json();
 
     const songs = songsData
-      ? Object.entries(songsData).map(([key, value]) => ({
-          ...value,
-          firebaseKey: key, // Add firebaseKey to each song
-        }))
+      ? Object.entries(songsData)
+          .map(([key, value]) => ({
+            ...value,
+            firebaseKey: key, // Add firebaseKey to each song
+          }))
+          .filter((song) => song.uid === uid)
       : [];
 
     // Fetch topics
@@ -28,7 +30,7 @@ const getSongsAndTopics = async () => {
     });
 
     const topicsData = await topicsResponse.json();
-    // const topics = topicsData ? Object.values(topicsData) : [];
+
     const topics = topicsData
       ? Object.entries(topicsData).map(([key, value]) => ({
           ...value,

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -2,14 +2,16 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useAuth } from '@/utils/context/authContext';
 import SongCard from '../components/SongCard';
 import { getSongsAndTopics } from '../api/songData';
 
 function Home() {
   const [songs, setSongs] = useState([]);
+  const { user } = useAuth();
 
   const refreshSongsAndTopics = () => {
-    getSongsAndTopics().then(setSongs);
+    getSongsAndTopics(user.uid).then(setSongs);
   };
 
   // useEffect(() => {
@@ -18,7 +20,7 @@ function Home() {
 
   useEffect(() => {
     refreshSongsAndTopics();
-  }, []);
+  }, [user]);
 
   return (
     <div className="container text-center my-4" id="songs-page">

--- a/src/components/forms/SongForm.js
+++ b/src/components/forms/SongForm.js
@@ -1,0 +1,17 @@
+// 'use client';
+
+// import React from 'react';
+// import { useRouter } from 'next/navigation';
+
+// const initialFormState = {
+//   title: '',
+//   hymnal: '',
+//   pageNumber: '',
+//   topicId: '',
+// };
+
+// export default function SongForm({ obj = initialFormState }) {
+//   const router = useRouter();
+
+//   return <div></div>;
+// }

--- a/src/utils/sample-data/songs.json
+++ b/src/utils/sample-data/songs.json
@@ -4,34 +4,39 @@
     "title": "Praise the Lord",
     "hymnal": "Praise for the Lord",
     "pageNumber": "531",
-    "topicId": "-M2BCq9XJtRp5KLf8vQZ"
+    "topicId": "-M2BCq9XJtRp5KLf8vQZ",
+    "uid": "Li3w1maYpsQp5mJDnYIrDGk4wvg2"
   },
   "-M1ABy27sQrVX6jPzWKL": {
     "firebaseKey": "-M1ABy27sQrVX6jPzWKL",
     "title": "Sweet Hour of Prayer",
     "hymnal": "Praise for the Lord",
     "pageNumber": "618",
-    "topicId": "-M2BDR7pLWQZkX83fTv6"
+    "topicId": "-M2BDR7pLWQZkX83fTv6",
+    "uid": "Li3w1maYpsQp5mJDnYIrDGk4wvg2"
   },
   "-M1AC78JfLgXT3nRqZ0Q": {
     "firebaseKey": "-M1AC78JfLgXT3nRqZ0Q",
     "title": "When I Survey the Wondrous Cross",
     "hymnal": "Praise for the Lord",
     "pageNumber": "742",
-    "topicId": "-M2BFJk3XW9LRpTQ57vZ"
+    "topicId": "-M2BFJk3XW9LRpTQ57vZ",
+    "uid": "Li3w1maYpsQp5mJDnYIrDGk4wvg2"
   },
   "-M1ADP4sVc7TkWQ2J9NY": {
     "firebaseKey": "-M1ADP4sVc7TkWQ2J9NY",
     "title": "Just As I Am",
     "hymnal": "Praise for the Lord",
     "pageNumber": "380",
-    "topicId": "-M2BGv5QLkT3JXRW8pZ9"
+    "topicId": "-M2BGv5QLkT3JXRW8pZ9",
+    "uid": "Li3w1maYpsQp5mJDnYIrDGk4wvg2"
   },
   "-M1AEMf8gLQXRp3TWZqK": {
     "firebaseKey": "-M1AEMf8gLQXRp3TWZqK",
     "title": "Glorify Your Name",
     "hynmal": "Praise for the Lord",
     "pageNumber": "929",
-    "topicId": "-M2BHX7kTpWv9LQR53ZK"
+    "topicId": "-M2BHX7kTpWv9LQR53ZK",
+    "uid": "Li3w1maYpsQp5mJDnYIrDGk4wvg2"
   }
 }


### PR DESCRIPTION
**Description
**

I added the ability for users to only be able to view, edit, and delete their own data.  Specifically, I:

- [ ] added "uid" as category in "Songs" entity of Firebase Realtime Database
- [ ] added "uid" field with my personal uid to songs.json file and uploaded to FB Realtime Database
- [ ] edited getSongsAndTopics api call to include "uid" and to filter results by uid
- [ ] edited songs.js file (all songs) by creaing "const { user } = useAuth();" and importing "useAuth," adding "user.uid" to getSongsAndTopics parameter in refreshSongsAndTopics function, and adding "user" to useEffect"


**Related Issue
**

#29 


**Motivation and Context
**

I read in the updated MVP guidelines that data must be user-specific, so I had to make these changes to make this happen.


**How Can This Be Tested?
**

Pulled down and manually tested


**Screenshots (if appropriate):
**

N/A


**Types of changes
**

[ ] Bug fix (non-breaking change which fixes an issue)
[ X] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)
