### PR TITLE
added getTopics promise and edited SongForm

### DIFF
--- a/src/api/songData.js
+++ b/src/api/songData.js
@@ -140,4 +140,25 @@ const updateSong = (payload) =>
       .catch(reject);
   });
 
-export { getSongsAndTopics, getSingleSongWithTopic, deleteSong, createSong, updateSong };
+// const getTopics = () =>
+//   new Promise((resolve, reject) => {
+//     fetch(`${endpoint}/topics.json`, {
+//       method: 'GET',
+//       headers: {
+//         'Content-Type': 'application/json',
+//       },
+//     })
+//       .then((response) => response.json())
+//       .then((data) => resolve(data))
+//       .catch(reject);
+//   });
+
+const getTopics = async () => {
+  const response = await fetch(`${endpoint}/topics.json`);
+  const data = await response.json();
+
+  // Transform Firebase's key-value pair structure into an array
+  return data ? Object.entries(data).map(([key, value]) => ({ ...value, firebaseKey: key })) : [];
+};
+
+export { getSongsAndTopics, getSingleSongWithTopic, deleteSong, createSong, updateSong, getTopics };

--- a/src/components/forms/SongForm.js
+++ b/src/components/forms/SongForm.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Form } from 'react-bootstrap';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/utils/context/authContext';
-import { createSong, updateSong, getSongsAndTopics } from '@/api/songData';
+import { createSong, updateSong, getTopics } from '@/api/songData';
 
 const initialFormState = {
   title: '',
@@ -19,10 +19,10 @@ export default function SongForm({ obj = initialFormState }) {
   const router = useRouter();
 
   const [formInput, setFormInput] = useState(obj);
-  const [songs, setSongs] = useState([]);
+  const [topics, setTopics] = useState([]);
 
   useEffect(() => {
-    getSongsAndTopics().then(setSongs);
+    getTopics().then(setTopics);
     if (obj.firebaseKey) setFormInput(obj);
   }, [obj, user]);
 
@@ -81,9 +81,9 @@ export default function SongForm({ obj = initialFormState }) {
           <Form.Select onChange={handleChange} aria-label="Topic" name="topicId" className="mb-3" value={formInput.topicId || ''} required>
             <option value="">Select ...</option>
             {/* Map over values. Remember to add a key prop. */}
-            {songs.map((song) => (
-              <option key={song.topicId} value={song.topicId}>
-                {song.topic.topicName}
+            {topics.map((topic) => (
+              <option key={topic.firebaseKey} value={topic.firebaseKey}>
+                {topic.topicName}
               </option>
             ))}
           </Form.Select>


### PR DESCRIPTION
**Description
**

I added a getTopics promise in the songData.js file and passed it into the SongForm.js file.  The form now correctly collects the song's title, hymnal, and page number as strings and provides a dropdown list of all topics.  The new song then displays on the "Songs" page after submitting.


**Related Issue
**

#29 #32 


**Motivation and Context
**

Users needed to be able to both submit new songs and edit existing ones through the Song Form presented to them after they click on either "Add a Song" in the navbar bar or "Edit Song" in the modal to the right of the song details listed on the "Song" page.


**How Can This Be Tested?
**

Pulled down and manually tested


**Screenshots (if appropriate):
**

N/A


**Types of changes
**

[ X] Bug fix (non-breaking change which fixes an issue)
[X ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)
