### PR TITLE
fixed styling issue with song lists cards

### DIFF
--- a/src/components/ListCard.js
+++ b/src/components/ListCard.js
@@ -15,7 +15,7 @@ export default function ListCard({ listObj }) {
   };
 
   return (
-    <div className="card border my-3" style={{ width: '100%', height: '7rem' }}>
+    <div className="card border my-3" style={{ width: '100%', height: 'auto' }}>
       <div className="card-body d-flex align-items-center">
         <div className="col">
           <p>{listObj.date}</p>


### PR DESCRIPTION
**Description
**

Changed the height of the Bootstrap card on the Song Lists page from "7rem" to "auto."  This allowed the complete list to be highlighted.


**Related Issue
**

#33 


**Motivation and Context
**

Users should be able to see their entire song list highlighted onscreen.


**How Can This Be Tested?
**

Pull down and manually test


**Screenshots (if appropriate):
**

N/A


**Types of changes
**

[ X] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)
