### PR TITLE
fixed new song lists errors

### DIFF
--- a/src/api/listData.js
+++ b/src/api/listData.js
@@ -100,8 +100,6 @@ const getSingleListWithSongs = async (uid, firebaseKey) => {
       songs,
     };
 
-    console.log('Fetched single list data:', singleList);
-
     return singleList;
   } catch (error) {
     console.error('Error fetching single list:', error);

--- a/src/app/lists/[firebaseKey]/page.js
+++ b/src/app/lists/[firebaseKey]/page.js
@@ -15,8 +15,6 @@ export default function ViewList({ params }) {
   const { user } = useAuth();
 
   const refreshLists = async () => {
-    if (!firebaseKey) return; // Avoid fetching data for `/lists/new`
-
     try {
       const fetchedList = await getSingleListWithSongs(user.uid, firebaseKey);
       setList(fetchedList || { songs: [] });
@@ -27,12 +25,15 @@ export default function ViewList({ params }) {
   };
 
   useEffect(() => {
-    if (firebaseKey) refreshLists();
+    // Call refreshLists only if firebaseKey exists (i.e., not on `/lists/new`)
+    if (firebaseKey) {
+      refreshLists();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [firebaseKey, user]);
 
+  // Handle the special case for `/lists/new` route
   if (pathname === '/lists/new') {
-    // Render the form for creating a new list
     return <SongListForm />;
   }
 
@@ -74,15 +75,7 @@ export default function ViewList({ params }) {
         <p>Song List has been deleted or is unavailable.</p>
       )}
 
-      <svg
-        onClick={handleDelete} // Invoke handleDelete directly
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        fill="currentColor"
-        className="bi bi-trash3"
-        viewBox="0 0 16 16"
-      >
+      <svg onClick={handleDelete} xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-trash3" viewBox="0 0 16 16">
         <path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5M11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1zm1.958 1-.846 10.58a1 1 0 0 1-.997.92h-6.23a1 1 0 0 1-.997-.92L3.042 3.5zm-7.487 1a.5.5 0 0 1 .528.47l.5 8.5a.5.5 0 0 1-.998.06L5 5.03a.5.5 0 0 1 .47-.53Zm5.058 0a.5.5 0 0 1 .47.53l-.5 8.5a.5.5 0 1 1-.998-.06l.5-8.5a.5.5 0 0 1 .528-.47M8 4.5a.5.5 0 0 1 .5.5v8.5a.5.5 0 0 1-1 0V5a.5.5 0 0 1 .5-.5" />
       </svg>
 

--- a/src/app/lists/new/page.js
+++ b/src/app/lists/new/page.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import SongListForm from '../../../../components/forms/SongListForm';
+import SongListForm from '../../../components/forms/SongListForm';
 
 export default function AddSongList() {
   return <SongListForm />;


### PR DESCRIPTION
**Description
**

I had incorrectly nested my lists => new page under [firebaseKey], so I created a new path (/lists/new), copied and pasted the contents of /lists/[firebaseKey]/new into lists/new.  The incorrect path of was causing the following error to appear in the dev tools but didn't affect the functionality of the app:

Error fetching single list: Error: List not found or does not belong to the specified UID.
at getSingleListWithSongs (listData.js:128:13)
at async refreshLists (page.js:21:27)

After completing these steps, the console error went away, and the app still works as needed.


**Related Issue
**

#35 


**Motivation and Context
**

Users needed to be able to post new song lists, and the app needed to be clear of any errors.


**How Can This Be Tested?
**

Pull down and test manually


**Screenshots (if appropriate):
**

N/A


**Types of changes
**

[ X] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)
